### PR TITLE
Replace deprecated method update_status_with_media

### DIFF
--- a/watch.py
+++ b/watch.py
@@ -66,7 +66,8 @@ class MyStreamer(TwythonStreamer):
 						Twython.html_for_tweet(tweet),\
 						datetime.fromtimestamp(int(tweet['timestamp_ms']) / 1000).replace(tzinfo=dateutil.tz.tzutc()))
 					image = open(image_path, 'rb')
-					rest.update_status_with_media(status=status, media=image)
+					media_id = rest.upload_media(media=image)['media_id']
+					rest.update_status(status=status, media_ids=[media_id])
 					image.close()
 					os.remove(image_path)
 


### PR DESCRIPTION
Method update_status_with_media is deprecated (https://dev.twitter.com/rest/reference/post/statuses/update_with_media).

We have to do this in 2 steps now:
1) upload media
2) update status

Reference: https://twython.readthedocs.io/en/latest/usage/advanced_usage.html#updating-status-with-image